### PR TITLE
Fix pullapprove.

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -7,7 +7,8 @@ reviewers:
     members:
         - cjllanwarne
         - Horneth
-        - scottfrazer
         - mcovarr
         - geoffjentry
         - kshakir
+        - kcibul
+        - ruchim


### PR DESCRIPTION
Adding ruchim and kcibul to pullapprove.
Removing scottfrazer from pullapprove to fix "'scottfrazer' is not a collaborator of this repo" error.