### PR TITLE
Ability to display ConditionalNode

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ organization := "org.broadinstitute"
 scalaVersion := "2.12.1"
 
 val catsV = "1.0.0-MF"
-val wdl4sV = "0.16-87308d0-SNAP"
+val wdl4sV = "0.16-8b84d1f-SNAP"
 
 lazy val versionSettings = Seq(
   // Upcoming release, or current if we're on the master branch

--- a/src/main/scala/wdltool/graph/package.scala
+++ b/src/main/scala/wdltool/graph/package.scala
@@ -16,7 +16,8 @@ package object graph {
 
     def graphName: String = dotSafe(graphNode match {
       case c: CallNode => s"call ${c.name}"
-      case s: ScatterNode => s"scatter"
+      case s: ScatterNode => "scatter"
+      case c: ConditionalNode => "conditional"
       case gin: OptionalGraphInputNodeWithDefault => s"${gin.womType.toWdlString} ${gin.name} = ..."
       case gin: GraphInputNode => s"${gin.womType.toWdlString} ${gin.name}"
       case gon: GraphOutputNode => s"${gon.womType.toWdlString} ${gon.name}"


### PR DESCRIPTION
For example this nested `if` inside a `scatter`:
```
import "import_me.wdl" as import_me

workflow outer {
  Array[Int] xs
  scatter (x in xs) {
    Boolean b
    if (b) {
      call import_me.inner as inner { input: i = x }
    }
  }
  output {
    Array[String?] outer_out = inner.out
  }
}
```

Produces this rather delightful graph:
![test](https://user-images.githubusercontent.com/13006282/30505569-79826e42-9a43-11e7-9f21-e82c9c8e9bc8.png)

To save you some time:
- "Why is the `Boolean b` inside the `scatter`?"
  - Because https://github.com/broadinstitute/wdl4s/issues/217
- [X] ~~"Why is the inner subworkflow not shown expanded too?"~~ TODONE!